### PR TITLE
Fix security vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
@@ -26,3 +27,4 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 dest
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "8.16.1"
-  - "10.16.1"
-  - "12.10.0"
+  - "12"
+  - "10"
+  - "8"
 after_success:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.1"
-  - "0.12"
-before_install:
-  - npm install istanbul -g
-env:
-  global:
-    - ISTANBUL_COVERAGE: yes
-
+  - "8.16.1"
+  - "10.16.1"
+  - "12.10.0"
 after_success:
-  - npm i coveralls
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && echo "Coverage data was sent to coveralls!"
+  - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "nyc mocha",
-    "precoverage": "npm test",
-    "coverage": "nyc report --reporter=lcovonly",
-    "precoveralls": "npm run coverage",
-    "coveralls": "cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/island205/posthtml-web-component#readme",
   "dependencies": {
     "debug": "^2.2.0",
-    "posthtml": "^0.7.0",
+    "posthtml": "^0.11.6",
     "request": "^2.67.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "Server Side Web Component Render.",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha && npm run coverage",
-    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec",
-    "coveralls": "npm run coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "test": "nyc mocha",
+    "precoverage": "npm test",
+    "coverage": "nyc report --reporter=lcovonly",
+    "precoveralls": "npm run coverage",
+    "coveralls": "cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "repository": {
     "type": "git",
@@ -29,15 +31,14 @@
   "homepage": "https://github.com/island205/posthtml-web-component#readme",
   "dependencies": {
     "debug": "^2.2.0",
+    "hoek": "^6.1.3",
     "posthtml": "^0.7.0",
     "request": "^2.67.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "coveralls": "^2.11.4",
-    "istanbul": "^0.4.5",
-    "jscoverage": "^0.6.0",
-    "mocha": "^2.3.4",
-    "mocha-lcov-reporter": "^1.0.0"
+    "coveralls": "^2.13.3",
+    "mocha": "^6.2.0",
+    "nyc": "^14.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/island205/posthtml-web-component#readme",
   "dependencies": {
     "debug": "^2.2.0",
-    "hoek": "^6.1.3",
     "posthtml": "^0.7.0",
     "request": "^2.67.0"
   },


### PR DESCRIPTION
Note: npm audit doesn't run clean yet -- we'll need to wait for the next version of coveralls to be released.